### PR TITLE
test(es5): Add tests for `symbol` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"eslint": "^6.4.0",
 		"foreach": "^2.0.5",
 		"function.prototype.name": "^1.1.1",
+		"has-symbols": "^1.0.0",
 		"object-inspect": "^1.6.0",
 		"object-is": "^1.0.1",
 		"replace": "^1.1.1",

--- a/test/es5.js
+++ b/test/es5.js
@@ -6,6 +6,7 @@ var is = require('object-is');
 var forEach = require('foreach');
 var functionName = require('function.prototype.name');
 var debug = require('object-inspect');
+var hasSymbols = require('has-symbols')();
 
 test('function properties', function (t) {
 	t.equal(toPrimitive.length, 1, 'length is 1');
@@ -22,6 +23,29 @@ test('primitives', function (t) {
 		t.ok(is(toPrimitive(i, String), i), 'toPrimitive(' + debug(i) + ', String) returns the same value');
 		t.ok(is(toPrimitive(i, Number), i), 'toPrimitive(' + debug(i) + ', Number) returns the same value');
 	});
+	t.end();
+});
+
+test('Symbols', { skip: !hasSymbols }, function (t) {
+	var symbols = [
+		Symbol('foo'),
+		Symbol.iterator,
+		Symbol['for']('foo') // eslint-disable-line no-restricted-properties
+	];
+	forEach(symbols, function (sym) {
+		t.equal(toPrimitive(sym), sym, 'toPrimitive(' + debug(sym) + ') returns the same value');
+		t.equal(toPrimitive(sym, String), sym, 'toPrimitive(' + debug(sym) + ', String) returns the same value');
+		t.equal(toPrimitive(sym, Number), sym, 'toPrimitive(' + debug(sym) + ', Number) returns the same value');
+	});
+
+	var primitiveSym = Symbol('primitiveSym');
+	var stringSym = Symbol.prototype.toString.call(primitiveSym);
+	var objectSym = Object(primitiveSym);
+	t.equal(toPrimitive(objectSym), primitiveSym, 'toPrimitive(' + debug(objectSym) + ') returns ' + debug(primitiveSym));
+
+	// This is different from ES2015, as the ES5 algorithm doesn't account for the existence of Symbols:
+	t.equal(toPrimitive(objectSym, String), stringSym, 'toPrimitive(' + debug(objectSym) + ', String) returns ' + debug(stringSym));
+	t.equal(toPrimitive(objectSym, Number), primitiveSym, 'toPrimitive(' + debug(objectSym) + ', Number) returns ' + debug(primitiveSym));
 	t.end();
 });
 

--- a/test/es6.js
+++ b/test/es6.js
@@ -7,7 +7,7 @@ var forEach = require('foreach');
 var functionName = require('function.prototype.name');
 var debug = require('object-inspect');
 
-var hasSymbols = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
+var hasSymbols = require('has-symbols')();
 var hasSymbolToPrimitive = hasSymbols && typeof Symbol.toPrimitive === 'symbol';
 
 test('function properties', function (t) {


### PR DESCRIPTION
This has been pointed out in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38947#discussion_r332063581.